### PR TITLE
Use `implementation` instead of `compile`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile group: 'com.zendesk', name: 'sdk', version: '1.11.0.1'
+    implementation 'com.facebook.react:react-native:+'
+    implementation group: 'com.zendesk', name: 'sdk', version: '1.11.0.1'
 }


### PR DESCRIPTION
#19 Getting rid of:

```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```