### PR TITLE
Fix installing using cocoapods

### DIFF
--- a/react-native-zendesk-support.podspec
+++ b/react-native-zendesk-support.podspec
@@ -4,7 +4,7 @@ json = File.read(File.join(__dir__, "package.json"))
 package = JSON.parse(json).deep_symbolize_keys
 
 Pod::Spec.new do |s|
-  s.name = package[:name]
+  s.name = package[:name].include?("/") ? package[:name].split("/").last : package[:name]
   s.version = package[:version]
   s.license = package[:license]
   s.authors = package[:author]


### PR DESCRIPTION
Issue #15 : When linking on iOS using cocoapods (the default used by running react-native link if the user has a Podfile) the install step fails because the podspec gets the name from the package name in the package.json file and it has a forward slash.
This commit fixes it by getting the name for the pod spec from the last part of the package name from the package.json