### PR TITLE
Issue #31: Create tickets in the background without zendesk's UI

### DIFF
--- a/android/android.iml
+++ b/android/android.iml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+<module external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,4 +22,6 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation group: 'com.zendesk', name: 'sdk', version: '1.11.0.1'
+    implementation group: 'com.zendesk', name: 'sdk-providers', version: '1.11.0.1'
+
 }

--- a/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
+++ b/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
@@ -7,6 +7,7 @@ package com.robertsheao.RNZenDeskSupport;
 
 import android.content.Intent;
 import android.app.Activity;
+import android.util.Log;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -15,6 +16,8 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.Promise;
+
 import com.zendesk.sdk.feedback.ui.ContactZendeskActivity;
 import com.zendesk.sdk.requests.RequestActivity;
 import com.zendesk.sdk.support.SupportActivity;
@@ -22,7 +25,11 @@ import com.zendesk.sdk.support.ContactUsButtonVisibility;
 import com.zendesk.sdk.model.access.AnonymousIdentity;
 import com.zendesk.sdk.model.access.Identity;
 import com.zendesk.sdk.model.request.CustomField;
+import com.zendesk.sdk.model.request.CreateRequest;
 import com.zendesk.sdk.network.impl.ZendeskConfig;
+import com.zendesk.sdk.network.RequestProvider;
+import com.zendesk.service.ErrorResponse;
+import com.zendesk.service.ZendeskCallback;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +39,8 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
   public RNZenDeskSupportModule(ReactApplicationContext reactContext) {
     super(reactContext);
   }
+  private static final String TAG = "RN Zendesk";
+  private Promise innerPromise;
 
   @Override
   public String getName() {
@@ -150,4 +159,49 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void createRequest(
+          ReadableMap request,
+          Promise promise) {
+    try {
+      // Get an instance of the RequestProvider from the ZendeskConfig
+      RequestProvider provider = ZendeskConfig.INSTANCE.provider().requestProvider();
+
+      // Build the request object from the javascript arguments
+      CreateRequest zdRequest = new CreateRequest();
+
+      zdRequest.setSubject(request.getString("subject"));
+      zdRequest.setDescription(request.getString("requestDescription"));
+
+      ArrayList<Object> list = request.getArray("tags").toArrayList();
+      List<String> tagsList = new ArrayList<>(list.size());
+      for (Object object : list) {
+        tagsList.add(object != null ? object.toString() : null);
+      }
+
+      zdRequest.setTags(tagsList);
+
+      innerPromise = promise;
+      // Create thew ZendeskCallback.
+      ZendeskCallback<CreateRequest> callback = new ZendeskCallback<CreateRequest>() {
+        @Override
+        public void onSuccess(CreateRequest createRequest) {
+          Log.d(TAG, "onSuccess: Ticket created!");
+          innerPromise.resolve(createRequest);
+        }
+
+        @Override
+        public void onError(ErrorResponse errorResponse) {
+          Log.d(TAG, "onError: " + errorResponse.getReason());
+          innerPromise.reject("onError", errorResponse.getReason());
+        }
+      } ;
+
+      // Call the provider method
+      provider.createRequest(zdRequest, callback);
+
+    } catch (Exception e) {
+      promise.reject("onException", e.getMessage());
+    }
+  }
 }

--- a/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
+++ b/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
@@ -187,7 +187,7 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
         @Override
         public void onSuccess(CreateRequest createRequest) {
           Log.d(TAG, "onSuccess: Ticket created!");
-          innerPromise.resolve(createRequest);
+          innerPromise.resolve(createRequest.getId());
         }
 
         @Override

--- a/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
+++ b/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.app.Activity;
 import android.util.Log;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -18,6 +19,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.Promise;
 
+import com.facebook.react.bridge.WritableMap;
 import com.zendesk.sdk.feedback.ui.ContactZendeskActivity;
 import com.zendesk.sdk.requests.RequestActivity;
 import com.zendesk.sdk.support.SupportActivity;
@@ -63,49 +65,49 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-    public void setupIdentity(ReadableMap identity) {
-      AnonymousIdentity.Builder builder = new AnonymousIdentity.Builder();
+  public void setupIdentity(ReadableMap identity) {
+    AnonymousIdentity.Builder builder = new AnonymousIdentity.Builder();
 
-      if (identity != null && identity.hasKey("customerEmail")) {
-        builder.withEmailIdentifier(identity.getString("customerEmail"));
-      }
-
-      if (identity != null && identity.hasKey("customerName")) {
-        builder.withNameIdentifier(identity.getString("customerName"));
-      }
-
-      ZendeskConfig.INSTANCE.setIdentity(builder.build());
+    if (identity != null && identity.hasKey("customerEmail")) {
+      builder.withEmailIdentifier(identity.getString("customerEmail"));
     }
+
+    if (identity != null && identity.hasKey("customerName")) {
+      builder.withNameIdentifier(identity.getString("customerName"));
+    }
+
+    ZendeskConfig.INSTANCE.setIdentity(builder.build());
+  }
 
   @ReactMethod
   public void showHelpCenterWithOptions(ReadableMap options) {
     SupportActivityBuilder.create()
-      .withOptions(options)
-      .show(getReactApplicationContext());
+            .withOptions(options)
+            .show(getReactApplicationContext());
   }
 
   @ReactMethod
   public void showCategoriesWithOptions(ReadableArray categoryIds, ReadableMap options) {
     SupportActivityBuilder.create()
-      .withOptions(options)
-      .withArticlesForCategoryIds(categoryIds)
-      .show(getReactApplicationContext());
+            .withOptions(options)
+            .withArticlesForCategoryIds(categoryIds)
+            .show(getReactApplicationContext());
   }
 
   @ReactMethod
   public void showSectionsWithOptions(ReadableArray sectionIds, ReadableMap options) {
     SupportActivityBuilder.create()
-      .withOptions(options)
-      .withArticlesForSectionIds(sectionIds)
-      .show(getReactApplicationContext());
+            .withOptions(options)
+            .withArticlesForSectionIds(sectionIds)
+            .show(getReactApplicationContext());
   }
 
   @ReactMethod
   public void showLabelsWithOptions(ReadableArray labels, ReadableMap options) {
     SupportActivityBuilder.create()
-      .withOptions(options)
-      .withLabelNames(labels)
-      .show(getReactApplicationContext());
+            .withOptions(options)
+            .withLabelNames(labels)
+            .show(getReactApplicationContext());
   }
 
   @ReactMethod
@@ -141,9 +143,9 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
     Activity activity = getCurrentActivity();
 
     if(activity != null){
-        Intent callSupportIntent = new Intent(getReactApplicationContext(), ContactZendeskActivity.class);
-        callSupportIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        getReactApplicationContext().startActivity(callSupportIntent);
+      Intent callSupportIntent = new Intent(getReactApplicationContext(), ContactZendeskActivity.class);
+      callSupportIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      getReactApplicationContext().startActivity(callSupportIntent);
     }
   }
 
@@ -153,9 +155,9 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
     Activity activity = getCurrentActivity();
 
     if(activity != null){
-        Intent supportHistoryIntent = new Intent(getReactApplicationContext(), RequestActivity.class);
-        supportHistoryIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        getReactApplicationContext().startActivity(supportHistoryIntent);
+      Intent supportHistoryIntent = new Intent(getReactApplicationContext(), RequestActivity.class);
+      supportHistoryIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      getReactApplicationContext().startActivity(supportHistoryIntent);
     }
   }
 
@@ -187,7 +189,18 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
         @Override
         public void onSuccess(CreateRequest createRequest) {
           Log.d(TAG, "onSuccess: Ticket created!");
-          innerPromise.resolve(createRequest.getId());
+
+          WritableMap map = Arguments.createMap();
+          WritableMap request = Arguments.createMap();
+
+          map.putString("description", createRequest.getDescription());
+          map.putString("id", createRequest.getId());
+          map.putString("email", createRequest.getEmail());
+          map.putString("subject", createRequest.getSubject());
+
+          request.putMap("request", map);
+
+          innerPromise.resolve(request);
         }
 
         @Override

--- a/ios/RNZenDeskSupport.m
+++ b/ios/RNZenDeskSupport.m
@@ -173,7 +173,16 @@ RCT_EXPORT_METHOD(createRequest:(NSDictionary *)request
             
         } else {
             // Handle the success
-            resolve(result);
+            ZDKDispatcherResponse * payload = result;
+            NSString *data = [[NSString alloc] initWithData:payload.data encoding:NSUTF8StringEncoding];
+            
+            // Deserialize the data JSON string to an NSDictionary
+            NSError *jsonError;
+            NSData *objectData = [data dataUsingEncoding:NSUTF8StringEncoding];
+            NSDictionary *json = [NSJSONSerialization JSONObjectWithData:objectData
+                                                                 options:NSJSONReadingMutableContainers
+                                                                   error:&jsonError];
+            resolve(json);
         }
     }];
 }

--- a/ios/RNZenDeskSupport.m
+++ b/ios/RNZenDeskSupport.m
@@ -13,6 +13,8 @@
 
 #import "RNZenDeskSupport.h"
 #import <ZendeskSDK/ZendeskSDK.h>
+#import <ZendeskProviderSDK/ZendeskProviderSDK.h>
+
 @implementation RNZenDeskSupport
 
 RCT_EXPORT_MODULE();
@@ -21,6 +23,7 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config){
     NSString *appId = [RCTConvert NSString:config[@"appId"]];
     NSString *zendeskUrl = [RCTConvert NSString:config[@"zendeskUrl"]];
     NSString *clientId = [RCTConvert NSString:config[@"clientId"]];
+    
     [[ZDKConfig instance]
      initializeWithAppId:appId
      zendeskUrl:zendeskUrl
@@ -39,7 +42,7 @@ RCT_EXPORT_METHOD(setupIdentity:(NSDictionary *)identity){
             zdIdentity.name = name;
         }
         [ZDKConfig instance].userIdentity = zdIdentity;
-
+        
     });
 }
 
@@ -140,5 +143,38 @@ RCT_EXPORT_METHOD(supportHistory){
         UIViewController *vc = [window rootViewController];
         [ZDKRequests presentRequestListWithViewController:vc];
     });
+}
+
+RCT_EXPORT_METHOD(createRequest:(NSDictionary *)request
+                  createRequestWithResolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    ZDKCreateRequest *zdRequest = [ZDKCreateRequest new];
+    NSString *subject = [RCTConvert NSString:request[@"subject"]];
+    if (subject != nil) {
+        zdRequest.subject = subject;
+    }
+    NSString *requestDescription = [RCTConvert NSString:request[@"requestDescription"]];
+    if (requestDescription != nil) {
+        zdRequest.requestDescription = requestDescription;
+    }
+    NSArray *tags = [RCTConvert NSArray:request[@"tags"]];
+    if (tags != nil) {
+        zdRequest.tags = tags;
+    }
+    
+    ZDKRequestProvider *provider = [[ZDKRequestProvider alloc] init];
+    [provider createRequest:zdRequest withCallback:^(id result, NSError *error) {
+        if (error) {
+            // Handle the error
+            reject(@"No Ticket", @"Failed to create ticket", error);
+            // Log the error
+            [ZDKLogger e:error.description];
+            
+        } else {
+            // Handle the success
+            resolve(result);
+        }
+    }];
 }
 @end


### PR DESCRIPTION
# Summary
The Zendesk SDK has a API providers that can create and query tickets in the background without invoking the UI. This is a React Native implementation of the [createrequest](https://developer.zendesk.com/embeddables/docs/ios/requests#createrequest) method that calls a request service to create a request on behalf of the end user.

# Changelog
[**Android**] [_NEW_] - Send ticket in the background
[**iOS**] [_NEW_] - Send ticket in the background

# Test Plan
```javascript
import ZendeskSupport from '@synapsestudios/react-native-zendesk-support'
...

// Initialize Zendesk
const config = {
  appId: ZENDESK_APP_ID,
  zendeskUrl: ZENDESK_URL,
  clientId: ZENDESK_CLIENT_ID,
}

ZendeskSupport.initialize(config);

// Define an identity
const identity = {
  customerEmail: "me@email.com",
  customerName: "Kaiser Soze",
}

ZendeskSupport.setupIdentity(identity)

// Send ticket in the background
// response is an object:
// {
//   request: {
//    id: // ticket id from the Zendesk database
//    email
//    subject
//    description
//  }
// }
const response = await ZendeskSupport.createRequest("Well, I believe in God and the only thing that scares me is Kaiser Soze.");
```