### PR TITLE
Use root project's sdk version if possible

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,11 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion safeExtGet('compileSdkVersion', 25)
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Trying to compile a project with sdk version 28 fails for this project.
Why not just grab the sdk version from the root project if it's available?